### PR TITLE
Multi-queue consumption

### DIFF
--- a/messagingclient/client.py
+++ b/messagingclient/client.py
@@ -27,6 +27,8 @@ class MessagingClient:
         return future.result(timeout=timeout)
 
     def consume(self, queue: str, callback: Callable = None, max_messages: int = 1):
+        print("MessagingClient.consume()")
+
         if callback is None:
             callback = _print
 
@@ -35,6 +37,7 @@ class MessagingClient:
 
         def callback_wrapper(payload):
             """Call user callback and send acknowledge."""
+            print("MessagingClient.consume().callback_wrapper()")
             callback(payload)
             payload.ack()
 
@@ -64,6 +67,7 @@ class MessagingClient:
         Refs:
         https://cloud.google.com/pubsub/docs/pull
         '''
+        print("MessagingClient.consume_multiple()")
 
         if isinstance(queues, str):
             return self.consume(queues, callback, max_messages)
@@ -78,6 +82,7 @@ class MessagingClient:
 
         def callback_wrapper(payload):
             """Call user callback and send acknowledge."""
+            print("MessagingClient.consume_multiple().callback_wrapper()")
             callback(payload)
             payload.ack()
 

--- a/messagingclient/client.py
+++ b/messagingclient/client.py
@@ -68,6 +68,7 @@ class MessagingClient:
         https://cloud.google.com/pubsub/docs/pull
         '''
         print("MessagingClient.consume_multiple()")
+        print("MessagingClient.consume_multiple() queues:", queues)
 
         if isinstance(queues, str):
             return self.consume(queues, callback, max_messages)

--- a/messagingclient/client.py
+++ b/messagingclient/client.py
@@ -1,8 +1,10 @@
+import time
 from typing import Any
-from typing import Union
+from typing import Union, List
 from typing import Callable
 from os import getenv
 
+from google.api_core import retry
 from google.cloud import pubsub_v1
 
 PROJECT_NAME = getenv("PROJECT_NAME", "neuromancer-seung-import")
@@ -48,3 +50,84 @@ class MessagingClient:
                 # terminate on any exception so that the worker isn't hung.
                 future.cancel()
                 print(f"stopped listening: {exc}")
+
+    def consume_multiple(self, queues: Union[str, List], callback: Callable = None, max_messages: int = 1):
+        '''
+        TODO: This function can completely replace consume() (i.e. be renamed consume(), deleting the older version),
+        but for development, I left the original consume() untouched and added this as a new function instead.
+        To avoid altering any code that currently calls consume(), the existing version could eventually be deleted
+        and this version could be renamed in its place.
+        
+        If one queue is provided, it will be consumed until the process is terminated.
+        If multiple queues are provided, they will be consumed in round robin fashion.
+
+        Refs:
+        https://cloud.google.com/pubsub/docs/pull
+        '''
+
+        if isinstance(queues, str):
+            return self.consume(queues, callback, max_messages)
+        if len(queues) == 1:
+            return self.consume(queues[0], callback, max_messages)
+        
+        if callback is None:
+            callback = _print
+
+        def _print(payload):
+            print(payload.data)
+
+        def callback_wrapper(payload):
+            """Call user callback and send acknowledge."""
+            callback(payload)
+            payload.ack()
+
+        # TODO: Note that most aspects of the subscription path are hardcoded.
+        # It could be further generalized, but for now, we will merely cycle over subscriptions.
+        subscription_names = [f"projects/{PROJECT_NAME}/subscriptions/{queue}" for queue in queues]
+        subscribers = [pubsub_v1.SubscriberClient() for _ in subscription_names]
+
+        queue_index = 0
+        quit = False
+        while not quit:
+            subscriber, subscription_name = subscribers[queue_index], subscription_names[queue_index]
+            queue_index = (queue_index + 1) % len(subscribers)
+
+            response = subscriber.pull(
+                request={"subscription": subscription_name, "max_messages": 1},
+                retry=retry.Retry(deadline=300),
+            )
+            if len(response.received_messages) == 0:
+                # TODO: Do I need to add a brief sleep here before looping around and trying again
+                # or is it relatively self-throttling, say via the retry/deadline arguments to subscriber.pull()?
+                time.sleep(0.1)
+                continue
+
+            ack_ids = []
+            # This for-loop is overkill. There really should only be only one message,
+            # as per the request.max_messages argument to subscriber.pull().
+            for received_message in response.received_messages:
+                try:
+                    print(f"Received message on subscription '{subscription_name}': {received_message.message.data}.")
+                    callback(received_message.message)
+                    ack_ids.append(received_message.ack_id)
+                except Exception as exc:
+                    # terminate on any exception so that the worker isn't hung.
+                    quit = True
+                    break
+            if quit:
+                break
+            
+            subscriber.acknowledge(
+                request={"subscription": subscription_name, "ack_ids": ack_ids}
+            )
+
+
+            # Another possible approach
+            # flow_control = pubsub_v1.types.FlowControl(max_messages=max_messages)
+            # future = subscriber.subscribe(subscription_name, callback=callback_wrapper, flow_control=flow_control)
+            # try:
+            #     future.result(timeout=1)
+            # except Exception as exc:
+            #     # terminate on any exception so that the worker isn't hung.
+            #     future.cancel()
+            #     print(f"stopped listening: {exc}")

--- a/messagingclient/client.py
+++ b/messagingclient/client.py
@@ -36,7 +36,7 @@ class MessagingClient:
             print(payload.data)
 
         def callback_wrapper(payload):
-            """Call user callback and send acknowledge."""]
+            """Call user callback and send acknowledge."""
             logging.info(f"MessagingClient.consume().callback_wrapper() Received message: {payload}.")
             callback(payload)
             payload.ack()


### PR DESCRIPTION
I added a new function that supports consuming messages from multiple queues (aka subscriptions) round-robin style. If messages are published to the queues in a low/high priority style, say with bulk messages going to one (low priority) queue and one-off messages going to the other (high priority) queue, then the round-robin structure will process messages evenly, back and forth between the two queues, until the shorter queue (higher priority) is empty, at which point the only remaining queue (low priority) will continue to process its remaining messages . . . until such a time as a new high priority message suddenly appears on the high priority queue, which will then be immediately processed before any further low-priority messages.