### PR TITLE
adding fixed N with idle timeout option

### DIFF
--- a/messagingclient/client.py
+++ b/messagingclient/client.py
@@ -1,5 +1,7 @@
 from concurrent import futures
+import contextlib
 import logging
+import signal
 import time
 from typing import Any
 from typing import Union, List
@@ -178,50 +180,109 @@ class MessagingClientConsumer:
         subscribers: List[pubsub_v1.SubscriberClient],
         subscription_names: List[str],
         callback: Callable,
-    ):
+        message_limit: int = 0,
+        idle_timeout: Union[int, float] = 0,
+    ) -> int:
+        """Synchronous pull loop over one or more subscriptions.
+
+        This is the single pull engine shared by ``consume_multiple`` (unbounded, N queues)
+        and ``consume_bounded`` (bounded/idle-exit, N queues).
+
+        Args:
+            subscribers (List[pubsub_v1.SubscriberClient]): list of SubscriberClient objects, one per subscription.
+            subscription_names (List[str]): list of subscription names, one per subscription.
+            callback (Callable): called with the ``PubsubMessage`` (has ``.data``/``.attributes``); the message is acknowledged after the callback returns.
+            message_limit (int): exit after this many messages are processed+acked. ``0`` = unbounded
+                (the original always-on behavior).
+            idle_timeout (Union[int, float]): exit after this many seconds with no message available across a full
+                round of the subscriptions. ``0`` = disabled.
+
+        Returns the number of messages processed. When either limit is set (i.e. a bounded
+        consumer), a SIGTERM handler is installed so pod termination finishes the in-flight
+        message and exits cleanly; unbounded callers keep the default SIGTERM behavior.
+        """
+        bounded = bool(message_limit) or bool(idle_timeout)
+        state = {"quit": False}
+        previous_handler = None
+        if bounded:
+            def _on_term(_signum, _frame):
+                logging.info(
+                    "MessagingClientConsumer._consume_round_robin() received SIGTERM; will exit after the current message."
+                )
+                state["quit"] = True
+
+            try:
+                previous_handler = signal.signal(signal.SIGTERM, _on_term)
+            except ValueError:
+                # signal handlers can only be installed on the main thread; skip otherwise.
+                previous_handler = None
+
+        processed = 0
+        last_message_time = time.monotonic()
         queue_index = 0
-        quit = False
-        while not quit:
-            subscriber, subscription_name = (
-                subscribers[queue_index],
-                subscription_names[queue_index],
-            )
-            queue_index = (queue_index + 1) % len(subscribers)
+        try:
+            while not state["quit"]:
+                subscriber, subscription_name = (
+                    subscribers[queue_index],
+                    subscription_names[queue_index],
+                )
+                wrapped_around = queue_index == len(subscribers) - 1
+                queue_index = (queue_index + 1) % len(subscribers)
 
-            response = subscriber.pull(
-                request={"subscription": subscription_name, "max_messages": 1},
-                retry=retry.Retry(deadline=300),
-            )
-            if len(response.received_messages) == 0:
-                # TODO: Do I need to add a brief sleep here before looping around and trying again
-                # or is it relatively self-throttling, say via the retry/deadline arguments to subscriber.pull()?
-                time.sleep(0.1)
-                continue
+                response = subscriber.pull(
+                    request={"subscription": subscription_name, "max_messages": 1},
+                    retry=retry.Retry(deadline=300),
+                )
+                if len(response.received_messages) == 0:
+                    # Only consider idling once we've checked every subscription this round.
+                    if idle_timeout and wrapped_around and (
+                        time.monotonic() - last_message_time
+                    ) >= idle_timeout:
+                        logging.info(
+                            f"MessagingClientConsumer._consume_round_robin() idle for {idle_timeout}s; exiting."
+                        )
+                        break
+                    time.sleep(0.1)
+                    continue
 
-            ack_ids = []
-            # This for-loop is overkill. There really should only be only one message,
-            # as per the request.max_messages argument to subscriber.pull().
-            for received_message in response.received_messages:
-                try:
-                    logging.info(
-                        f"MessagingClientConsumer._consume_round_robin() Received message on subscription '{subscription_name}': {received_message.message.data}."
-                    )
-                    received_message.message.attributes["__subscription_name"] = subscription_name
-                    callback(received_message.message)
-                    ack_ids.append(received_message.ack_id)
-                except Exception as exc:
-                    # terminate on any exception so that the worker isn't hung.
-                    logging.info(
-                        f"MessagingClientConsumer._consume_round_robin() Exception (will stop listening now): {exc}"
-                    )
-                    quit = True
+                ack_ids = []
+                stop = False
+                # There should only be one message per pull (max_messages=1).
+                for received_message in response.received_messages:
+                    try:
+                        logging.info(
+                            f"MessagingClientConsumer._consume_round_robin() Received message on subscription '{subscription_name}': {received_message.message.data}."
+                        )
+                        received_message.message.attributes["__subscription_name"] = subscription_name
+                        callback(received_message.message)
+                        ack_ids.append(received_message.ack_id)
+                    except Exception as exc:
+                        # terminate on any exception so that the worker isn't hung; do NOT
+                        # ack -> Pub/Sub redelivers the message.
+                        logging.info(
+                            f"MessagingClientConsumer._consume_round_robin() Exception (will stop listening now): {exc}"
+                        )
+                        stop = True
+                        break
+                if stop:
                     break
-            if quit:
-                break
 
-            subscriber.acknowledge(
-                request={"subscription": subscription_name, "ack_ids": ack_ids}
-            )
+                subscriber.acknowledge(
+                    request={"subscription": subscription_name, "ack_ids": ack_ids}
+                )
+                processed += len(ack_ids)
+                last_message_time = time.monotonic()
+
+                if message_limit and processed >= message_limit:
+                    logging.info(
+                        f"MessagingClientConsumer._consume_round_robin() processed {processed}/{message_limit} message(s); exiting."
+                    )
+                    break
+        finally:
+            if bounded and previous_handler is not None:
+                signal.signal(signal.SIGTERM, previous_handler)
+
+        return processed
 
     def consume_multiple(
         self, queues: Union[str, List], callback: Callable = None, max_messages: int=1
@@ -260,6 +321,59 @@ class MessagingClientConsumer:
         except Exception as exc:
             logging.info(f"MessagingClientConsumer.consume_multiple() stopped listening: {exc}")
 
+    def consume_bounded(
+        self,
+        queues: Union[str, List],
+        callback: Callable = None,
+        message_limit: int = 0,
+        idle_timeout: Union[int, float] = 0,
+    ) -> int:
+        """Consume one or more queues but exit after a bounded amount of work.
+
+        Thin wrapper over ``_consume_round_robin`` (the shared pull engine). Unlike
+        ``consume()`` (a streaming subscriber that blocks forever), this pulls one message at
+        a time and returns once a limit is reached, so a pod running it does a bounded chunk
+        of work and exits -- which is what a KEDA ScaledJob wants (one Job per N messages,
+        launched from queue backlog).
+
+        Args:
+            queues: a single subscription name (str) or a list of them (short form). A list is
+                consumed round-robin, with the limits counted across all of them.
+            callback: called with the ``PubsubMessage`` (has ``.data``/``.attributes``); the
+                message is acknowledged after the callback returns.
+            message_limit: exit after this many messages (total across all queues) are
+                processed+acked. ``0`` = unbounded.
+            idle_timeout: exit after this many seconds with no message available from any
+                queue. ``0`` = disabled.
+
+        Returns the number of messages processed. A SIGTERM handler is installed (by the
+        engine) so pod termination finishes the in-flight message and exits cleanly; on a
+        callback exception the message is left unacked so Pub/Sub + the Job's backoffLimit
+        retry it.
+        """
+        if callback is None:
+            def callback(payload):
+                print(payload.data)
+
+        if isinstance(queues, str):
+            queues = [queues]
+        subscription_names = [
+            f"projects/{PROJECT_NAME}/subscriptions/{queue}" for queue in queues
+        ]
+        with contextlib.ExitStack() as stack:
+            subscribers = [
+                stack.enter_context(pubsub_v1.SubscriberClient())
+                for _ in subscription_names
+            ]
+            return self._consume_round_robin(
+                subscribers,
+                subscription_names,
+                callback,
+                message_limit=message_limit,
+                idle_timeout=idle_timeout,
+            )
+
+
 class MessagingClient:
     """
     This class merely exists for back compatibility with existing code that creates a "MessagingClient" object.
@@ -289,9 +403,20 @@ class MessagingClient:
             self.consumer = MessagingClientConsumer()
         return self.consumer.consume(queue, callback, max_messages)
     
-    def consume_multiple(   
+    def consume_multiple(
         self, queues: Union[str, List], callback: Callable = None, max_messages: int=1
     ):
         if not self.consumer:
             self.consumer = MessagingClientConsumer()
         return self.consumer.consume_multiple(queues, callback, max_messages)
+
+    def consume_bounded(
+        self,
+        queues: Union[str, List],
+        callback: Callable = None,
+        message_limit: int = 0,
+        idle_timeout: Union[int, float] = 0,
+    ) -> int:
+        if not self.consumer:
+            self.consumer = MessagingClientConsumer()
+        return self.consumer.consume_bounded(queues, callback, message_limit, idle_timeout)

--- a/tests/test_consume_bounded.py
+++ b/tests/test_consume_bounded.py
@@ -1,0 +1,155 @@
+"""Tests for MessagingClientConsumer.consume_bounded (bounded/idle-exit pull consumer)."""
+
+import os
+import signal
+from unittest.mock import MagicMock, patch
+
+from messagingclient.client import MessagingClientConsumer
+
+
+class FakeMessage:
+    def __init__(self, data=b"payload", attributes=None):
+        self.data = data
+        self.attributes = attributes if attributes is not None else {}
+
+
+class FakeReceived:
+    def __init__(self, message, ack_id):
+        self.message = message
+        self.ack_id = ack_id
+
+
+class FakePullResponse:
+    def __init__(self, received_messages):
+        self.received_messages = received_messages
+
+
+def _patched_subscriber(pull_side_effect):
+    """Return (patcher, subscriber_mock) where SubscriberClient() context-manages the mock."""
+    subscriber = MagicMock()
+    subscriber.pull.side_effect = pull_side_effect
+    client_cls = MagicMock()
+    client_cls.return_value.__enter__.return_value = subscriber
+    patcher = patch("messagingclient.client.pubsub_v1.SubscriberClient", client_cls)
+    return patcher, subscriber
+
+
+def test_processes_exactly_n_then_returns():
+    # Always a message available; bounded by max_messages.
+    def pull(request, retry):
+        return FakePullResponse([FakeReceived(FakeMessage(), "ack")])
+
+    patcher, subscriber = _patched_subscriber(pull)
+    calls = []
+    with patcher:
+        processed = MessagingClientConsumer().consume_bounded(
+            "q", callback=lambda m: calls.append(m), message_limit=3
+        )
+
+    assert processed == 3
+    assert len(calls) == 3
+    assert subscriber.acknowledge.call_count == 3
+    # subscription name is injected into the message attributes for the callback
+    assert calls[0].attributes["__subscription_name"].endswith("/subscriptions/q")
+
+
+def test_idle_timeout_returns_zero_on_empty_queue():
+    def pull(request, retry):
+        return FakePullResponse([])  # queue always empty
+
+    patcher, subscriber = _patched_subscriber(pull)
+    calls = []
+    with patcher:
+        processed = MessagingClientConsumer().consume_bounded(
+            "q", callback=lambda m: calls.append(m), message_limit=0, idle_timeout=0.05
+        )
+
+    assert processed == 0
+    assert calls == []
+    subscriber.acknowledge.assert_not_called()
+
+
+def test_sigterm_breaks_after_current_message():
+    # A few messages then empty (bounded so the test can't hang if SIGTERM is ignored).
+    remaining = [FakeReceived(FakeMessage(), f"ack{i}") for i in range(3)]
+
+    def pull(request, retry):
+        if remaining:
+            return FakePullResponse([remaining.pop(0)])
+        return FakePullResponse([])
+
+    patcher, subscriber = _patched_subscriber(pull)
+    calls = []
+
+    def callback(msg):
+        calls.append(msg)
+        os.kill(os.getpid(), signal.SIGTERM)  # ask the worker to stop
+
+    with patcher:
+        processed = MessagingClientConsumer().consume_bounded(
+            "q", callback=callback, message_limit=0, idle_timeout=0.5
+        )
+
+    # It finished the in-flight message and then exited (did not drain all 3).
+    assert processed == 1
+    assert len(calls) == 1
+    assert subscriber.acknowledge.call_count == 1
+
+
+def test_multiple_queues_round_robin_with_message_limit():
+    # One subscriber per queue; round-robins across both. message_limit is total.
+    subscribers = {}
+
+    def make_pull(name):
+        def pull(request, retry):
+            return FakePullResponse([FakeReceived(FakeMessage(), f"{name}-ack")])
+        return pull
+
+    # Patch SubscriberClient so each constructed client is a distinct mock whose
+    # __enter__ returns itself; ExitStack.enter_context(client) -> client.
+    created = []
+
+    def new_client():
+        sub = MagicMock()
+        sub.__enter__.return_value = sub
+        idx = len(created)
+        sub.pull.side_effect = make_pull(f"q{idx}")
+        created.append(sub)
+        return sub
+
+    with patch("messagingclient.client.pubsub_v1.SubscriberClient", side_effect=new_client):
+        calls = []
+        processed = MessagingClientConsumer().consume_bounded(
+            ["qa", "qb"], callback=lambda m: calls.append(m), message_limit=4
+        )
+
+    assert processed == 4
+    assert len(calls) == 4
+    assert len(created) == 2  # one subscriber per queue
+    # round-robin: work split across both subscribers
+    assert created[0].acknowledge.call_count == 2
+    assert created[1].acknowledge.call_count == 2
+    # subscription names carry through to each message
+    subs = {m.attributes["__subscription_name"] for m in calls}
+    assert subs == {
+        "projects/neuromancer-seung-import/subscriptions/qa",
+        "projects/neuromancer-seung-import/subscriptions/qb",
+    }
+
+
+def test_callback_exception_does_not_ack_and_exits():
+    def pull(request, retry):
+        return FakePullResponse([FakeReceived(FakeMessage(), "ack")])
+
+    patcher, subscriber = _patched_subscriber(pull)
+
+    def callback(_msg):
+        raise RuntimeError("boom")
+
+    with patcher:
+        processed = MessagingClientConsumer().consume_bounded(
+            "q", callback=callback, message_limit=5
+        )
+
+    assert processed == 0
+    subscriber.acknowledge.assert_not_called()  # unacked -> Pub/Sub redelivers


### PR DESCRIPTION
This adds a new method that allows for workers to pull N messages and then quit, rather than polling forever.  Also it provides an option that if there are no messages to consume after a period of time that the worker quits.

This would allow a use of launching N workers to do K jobs where each worker is allocated K/N jobs, and the jobs will simply complete when each worker has consumed their allocated number of jobs.  